### PR TITLE
Updated client and server to use latest TestStand gRPC API changes

### DIFF
--- a/Server/StartupTestStandGrpc.cs
+++ b/Server/StartupTestStandGrpc.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using NationalInstruments.TestStand.gRPC.Server;
+using NationalInstruments.TestStand.Grpc.Server;
 using static System.FormattableString;
 
 namespace TestStandGrpcApi


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Updated namespace server namespace to NationalInstruments.TestStand.Grpc.Server
- Updated Engine's lifetime to use infinite lifetime value from API in client application
- Updated client application to use updated TestStand gRPC API names

### Why should this Pull Request be merged?

Without the changes, client and server applications will not compile

### What testing has been done?

Verified client and server compile and work with the new API changes